### PR TITLE
Added --pan-threshold parameter

### DIFF
--- a/src/ExplicitType.hpp
+++ b/src/ExplicitType.hpp
@@ -1,0 +1,56 @@
+#ifndef SRC_EXPLICITTYPE_HPP
+#define SRC_EXPLICITTYPE_HPP
+
+#include <utility>
+#include <iostream>
+
+namespace car {
+
+template <typename Tag, typename T>
+class ExplicitType {
+public:
+	ExplicitType() = default;
+	explicit ExplicitType(const T& v):v(v) {}
+	explicit ExplicitType(T&& v):v(std::move(v)) {}
+	ExplicitType(const ExplicitType&) = default;
+	ExplicitType(ExplicitType&&) = default;
+
+	ExplicitType& operator=(const ExplicitType&) = default;
+	ExplicitType& operator=(ExplicitType&&) = default;
+
+	const T& value() const { return v; }
+	T& value() { return v; }
+private:
+	T v;
+};
+
+#define EXPLICIT_TYPE_OP(op) \
+template <typename Tag, typename T> \
+bool operator op (const ExplicitType<Tag, T>& lhs, const ExplicitType<Tag, T>& rhs) { \
+	return lhs.value() op rhs.value();\
+}
+
+EXPLICIT_TYPE_OP(==)
+EXPLICIT_TYPE_OP(!=)
+EXPLICIT_TYPE_OP(<)
+EXPLICIT_TYPE_OP(>)
+EXPLICIT_TYPE_OP(<=)
+EXPLICIT_TYPE_OP(>=)
+
+#undef EXPLICIT_TYPE_OP
+
+template <typename Tag, typename T>
+std::ostream& operator<<(std::ostream& os, const ExplicitType<Tag, T>& t) {
+	return os << t.value();
+}
+
+template <typename Tag, typename T>
+std::istream& operator>>(std::istream& is, const ExplicitType<Tag, T>& t) {
+	return is >> t.value();
+}
+
+
+}
+
+
+#endif /* SRC_EXPLICITTYPE_HPP */

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -154,6 +154,8 @@ Parameters parseParameters(int argc, char **argv) {
 				"Maximum resolution of the view.")
 		("pan-mode", po::value<PanMode>(&parameters.panMode)->default_value(parameters.panMode),
 				panModeDescription.c_str())
+		("pan-threshold", po::value<std::string>(),
+				"The maximum amount that the car moves from the screen center before the screen gets panned. The value is in meter (m), pixels (px) or percent (%).")
 	;
 
 	po::options_description commandLineDescription("Options");
@@ -190,6 +192,10 @@ Parameters parseParameters(int argc, char **argv) {
 	}
 	if (vm.count("input-population")) {
 		parameters.populationInputFile = vm["input-population"].as<std::string>();
+	}
+
+	if (vm.count("pan-threshold")) {
+		parameters.panThreshold = parseScreenDimenstion(vm["pan-threshold"].as<std::string>());
 	}
 
 	if (parameters.minPixelsPerMeter < 0.f) {

--- a/src/Parameters.hpp
+++ b/src/Parameters.hpp
@@ -8,6 +8,7 @@
 #include <boost/optional.hpp>
 
 #include "MathExpression.hpp"
+#include "ScreenDimension.hpp"
 
 namespace car {
 
@@ -71,6 +72,7 @@ struct Parameters {
 	float minPixelsPerMeter = 5.f;
 	float maxPixelsPerMeter = 10.f;
 	PanMode panMode = PanMode::fit;
+	ScreenDimension panThreshold{Meters(0)};
 };
 
 //May throw if something goes wrong with parsing

--- a/src/RealTimeGameManager.hpp
+++ b/src/RealTimeGameManager.hpp
@@ -47,6 +47,7 @@ protected:
 	bool showTelemetryText = true;
 	bool showTelemetryGraphs = false;
 	float pixelsPerMeter = 0.f;
+	float panThreshold = 0.f;
 
 	Telemetry speedTelemetry;
 	Telemetry accelerationTelemetry;

--- a/src/ScreenDimension.cpp
+++ b/src/ScreenDimension.cpp
@@ -1,0 +1,41 @@
+#include "ScreenDimension.hpp"
+#include <boost/spirit/include/qi.hpp>
+#include <stdexcept>
+#include <sstream>
+#include <iostream>
+
+namespace qi = boost::spirit::qi;
+namespace phx = boost::phoenix;
+
+namespace car {
+
+ScreenDimension parseScreenDimenstion(const std::string& s) {
+	ScreenDimension result;
+	auto meterSetter = [&](float f) { result = Meters{f}; };
+	auto percentSetter = [&](float f) { result = Percent{f}; };
+	auto pixelSetter = [&](unsigned i) { result = Pixels{i}; };
+
+	auto it = s.begin();
+	bool success = qi::phrase_parse(it, s.end(),
+		(
+		   	( qi::float_[meterSetter] >> "m" ) |
+			( qi::float_[percentSetter] >> "%" ) |
+			( qi::uint_[pixelSetter] >> "p" >> -qi::lit("x") )
+		), boost::spirit::ascii::space);
+
+	if (!success || it != s.end()) {
+		std::ostringstream ss;
+		ss << "Lexical error parsing screen dimension:\n" << s << "\n";
+		for (auto it2 = s.begin(); it2 != it; ++it2) {
+			ss << ' ';
+		}
+		ss << '^';
+		throw std::logic_error{ss.str()};
+	}
+
+	return result;
+}
+
+
+}
+

--- a/src/ScreenDimension.hpp
+++ b/src/ScreenDimension.hpp
@@ -1,0 +1,49 @@
+#ifndef SRC_SCREENDIMENSION_HPP
+#define SRC_SCREENDIMENSION_HPP
+
+#include <boost/variant.hpp>
+#include <SFML/Graphics.hpp>
+#include "ExplicitType.hpp"
+
+namespace car {
+
+using Meters = ExplicitType<struct tag_Meters, float>;
+using Percent = ExplicitType<struct tag_Percent, float>;
+using Pixels = ExplicitType<struct tag_Pixels, unsigned>;
+
+using ScreenDimension = boost::variant<Meters, Percent, Pixels>;
+
+class ScreenDimensionConverter {
+public:
+	using result_type = float;
+
+	ScreenDimensionConverter(sf::Vector2f viewSize, float pixelsPerMeter):
+		viewSize(viewSize), pixelsPerMeter(pixelsPerMeter)
+	{}
+
+	result_type operator()(const Meters& meters) const {
+		return meters.value();
+	}
+
+	result_type operator()(const Percent& percent) const {
+		// size / 2 * percent / 100
+		return std::min(viewSize.x, viewSize.y) * percent.value() / 200.f;
+	}
+
+	result_type operator()(const Pixels& pixels) const {
+		return pixels.value() / pixelsPerMeter;
+	}
+private:
+	sf::Vector2f viewSize;
+	float pixelsPerMeter;
+};
+
+ScreenDimension parseScreenDimenstion(const std::string& s);
+
+
+}
+
+
+
+
+#endif /* SRC_SCREENDIMENSION_HPP */


### PR DESCRIPTION
Threshold can be given in meter, pixel or percentage of screen size. Use spirit parser in command line to determine measurement unit.

Does not work well with `--pan-mode=pan` yet.
